### PR TITLE
Add dynamic theming and animated UI

### DIFF
--- a/learning-games/src/App.css
+++ b/learning-games/src/App.css
@@ -64,20 +64,20 @@
   position: relative;
   padding: 0;
   border: 2px solid transparent;
-  border-radius: 10px;
+  border-radius: 16px;
   text-decoration: none;
   display: block;
   overflow: hidden;
-  background: var(--color-background);
+  background: var(--badho-hero-gradient);
   color: var(--color-text-dark);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 8px 32px rgba(48, 63, 159, 0.15);
+  transition: transform 0.3s, box-shadow 0.3s;
   height: 200px;
   cursor: pointer;
 }
 .game-card:hover {
-  transform: scale(1.05);
-  border-color: var(--color-brand);
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 12px 48px rgba(48, 63, 159, 0.25);
 }
 
 .game-card:hover .game-icon {

--- a/learning-games/src/components/MiniGameBackgrounds.css
+++ b/learning-games/src/components/MiniGameBackgrounds.css
@@ -1,0 +1,21 @@
+.willpower-bg {
+  background: linear-gradient(#8EC5FC, #E0C3FC);
+  background-attachment: fixed;
+}
+.goal-orb-bg {
+  background: radial-gradient(circle at center, #1e3a8a 0%, #000 80%);
+  color: #fff;
+  background-attachment: fixed;
+}
+.time-tunnel-bg {
+  background: radial-gradient(circle, #2196f3 0%, #303f9f 100%);
+  background-attachment: fixed;
+}
+.confidence-bg {
+  background: linear-gradient(#FFDEE9, #B5FFFC);
+  background-attachment: fixed;
+}
+.triumph-bg {
+  background: linear-gradient(#a8e063, #56ab2f);
+  background-attachment: fixed;
+}

--- a/learning-games/src/components/ProgressSummary.tsx
+++ b/learning-games/src/components/ProgressSummary.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { getApiBase } from '../utils/api'
+import ProgressRing from './ui/ProgressRing'
 
 interface ProgressSummaryProps {
   totalPoints?: number
@@ -27,7 +28,7 @@ export default function ProgressSummary({ totalPoints, badges, goalPoints }: Pro
   return (
     <div className="progress-summary">
       <p>Total Points: {pts}</p>
-      <progress value={pts} max={goalPoints} />
+      <ProgressRing progress={(pts / goalPoints) * 100} />
       <p>Badges Earned: {earned.length}</p>
       <div className="badge-icons">
         {earned.map((b) => (

--- a/learning-games/src/components/confidenceCavern.tsx
+++ b/learning-games/src/components/confidenceCavern.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { fetchChallenge, postAction } from '../services/aiService'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
+import './MiniGameBackgrounds.css'
+import { ConfidenceTorch } from './icons'
 
 interface Props {
   ageGroup: string
@@ -21,7 +23,8 @@ export default function ConfidenceCavern({ ageGroup, onComplete }: Props) {
   }
 
   return (
-    <div>
+    <div className="confidence-bg">
+      <ConfidenceTorch />
       <h2>Confidence Cavern</h2>
       <p>Face challenges to boost confidence.</p>
       <button className="btn-primary" onClick={handleAction}>Finish</button>

--- a/learning-games/src/components/goalOrbQuest.tsx
+++ b/learning-games/src/components/goalOrbQuest.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { fetchChallenge, postAction } from '../services/aiService'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
+import './MiniGameBackgrounds.css'
+import { GoalOrb } from './icons'
 
 interface Props {
   ageGroup: string
@@ -21,7 +23,8 @@ export default function GoalOrbQuest({ ageGroup, onComplete }: Props) {
   }
 
   return (
-    <div>
+    <div className="goal-orb-bg">
+      <GoalOrb />
       <h2>Goal Orb Quest</h2>
       <p>Collect orbs by setting clear goals.</p>
       <button className="btn-primary" onClick={handleAction}>Finish</button>

--- a/learning-games/src/components/icons/ConfidenceTorch.tsx
+++ b/learning-games/src/components/icons/ConfidenceTorch.tsx
@@ -1,0 +1,10 @@
+import '../icons/icons.css'
+
+export default function ConfidenceTorch() {
+  return (
+    <svg className="icon confidence-torch" viewBox="0 0 64 64" role="img" aria-label="Confidence torch">
+      <path d="M30 50h4l2 10h-8z" />
+      <path className="flame" d="M32 14c4 4 6 8 6 12a6 6 0 1 1-12 0c0-4 2-8 6-12z" />
+    </svg>
+  )
+}

--- a/learning-games/src/components/icons/GoalOrb.tsx
+++ b/learning-games/src/components/icons/GoalOrb.tsx
@@ -1,0 +1,9 @@
+import '../icons/icons.css'
+
+export default function GoalOrb() {
+  return (
+    <svg className="icon goal-orb" viewBox="0 0 64 64" role="img" aria-label="Goal orb">
+      <circle cx="32" cy="32" r="20" />
+    </svg>
+  )
+}

--- a/learning-games/src/components/icons/TimeClock.tsx
+++ b/learning-games/src/components/icons/TimeClock.tsx
@@ -1,0 +1,10 @@
+import '../icons/icons.css'
+
+export default function TimeClock() {
+  return (
+    <svg className="icon time-clock" viewBox="0 0 64 64" role="img" aria-label="Time clock">
+      <circle cx="32" cy="32" r="22" fill="none" stroke="currentColor" strokeWidth="2" />
+      <line x1="32" y1="32" x2="32" y2="16" className="hand" />
+    </svg>
+  )
+}

--- a/learning-games/src/components/icons/TriumphTree.tsx
+++ b/learning-games/src/components/icons/TriumphTree.tsx
@@ -1,0 +1,10 @@
+import '../icons/icons.css'
+
+export default function TriumphTree() {
+  return (
+    <svg className="icon triumph-tree" viewBox="0 0 64 64" role="img" aria-label="Triumph tree">
+      <rect x="28" y="40" width="8" height="20" />
+      <circle cx="32" cy="32" r="16" className="leaf" />
+    </svg>
+  )
+}

--- a/learning-games/src/components/icons/WillpowerBadge.tsx
+++ b/learning-games/src/components/icons/WillpowerBadge.tsx
@@ -1,0 +1,9 @@
+import '../icons/icons.css'
+
+export default function WillpowerBadge() {
+  return (
+    <svg className="icon willpower-badge" viewBox="0 0 64 64" role="img" aria-label="Willpower badge">
+      <path d="M32 4l20 8v14c0 14-9 26-20 34C21 52 12 40 12 26V12l20-8z" />
+    </svg>
+  )
+}

--- a/learning-games/src/components/icons/icons.css
+++ b/learning-games/src/components/icons/icons.css
@@ -1,0 +1,67 @@
+.icon {
+  width: 64px;
+  height: 64px;
+  display: inline-block;
+}
+
+.willpower-badge {
+  fill: var(--badho-sky-blue);
+  stroke: var(--badho-accent-indigo);
+  stroke-width: 2;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 0.9; }
+  50% { transform: scale(1.1); opacity: 1; }
+}
+
+.goal-orb {
+  fill: var(--badho-sunflower);
+  stroke: var(--badho-accent-indigo);
+  stroke-width: 2;
+  animation: rotate 4s linear infinite;
+}
+
+@keyframes rotate {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.time-clock .hand {
+  stroke: var(--badho-accent-indigo);
+  stroke-linecap: round;
+  animation: spin 60s linear infinite;
+  transform-origin: 32px 32px;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.confidence-torch .flame {
+  fill: var(--badho-warm-orange);
+  animation: flicker 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes flicker {
+  from { transform: scale(1); opacity: 0.8; }
+  to { transform: scale(1.1); opacity: 1; }
+}
+
+.triumph-tree {
+  fill: var(--badho-leaf-green);
+  stroke: var(--badho-accent-indigo);
+  stroke-width: 2;
+}
+
+.triumph-tree .leaf {
+  fill: var(--badho-leaf-green);
+  animation: fall 3s ease-in-out infinite;
+}
+
+@keyframes fall {
+  0% { transform: translateY(0); opacity: 1; }
+  100% { transform: translateY(8px); opacity: 0; }
+}

--- a/learning-games/src/components/icons/index.ts
+++ b/learning-games/src/components/icons/index.ts
@@ -1,0 +1,5 @@
+export { default as WillpowerBadge } from './WillpowerBadge'
+export { default as GoalOrb } from './GoalOrb'
+export { default as TimeClock } from './TimeClock'
+export { default as ConfidenceTorch } from './ConfidenceTorch'
+export { default as TriumphTree } from './TriumphTree'

--- a/learning-games/src/components/timeTunnelTracker.tsx
+++ b/learning-games/src/components/timeTunnelTracker.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { fetchChallenge, postAction } from '../services/aiService'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
+import './MiniGameBackgrounds.css'
+import { TimeClock } from './icons'
 
 interface Props {
   ageGroup: string
@@ -21,7 +23,8 @@ export default function TimeTunnelTracker({ ageGroup, onComplete }: Props) {
   }
 
   return (
-    <div>
+    <div className="time-tunnel-bg">
+      <TimeClock />
       <h2>Time Tunnel Tracker</h2>
       <p>Manage tasks against the clock.</p>
       <button className="btn-primary" onClick={handleAction}>Finish</button>

--- a/learning-games/src/components/treeOfTriumph.tsx
+++ b/learning-games/src/components/treeOfTriumph.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { fetchChallenge, postAction } from '../services/aiService'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
+import './MiniGameBackgrounds.css'
+import { TriumphTree } from './icons'
 
 interface Props {
   ageGroup: string
@@ -21,7 +23,8 @@ export default function TreeOfTriumph({ ageGroup, onComplete }: Props) {
   }
 
   return (
-    <div>
+    <div className="triumph-bg">
+      <TriumphTree />
       <h2>Tree of Triumph</h2>
       <p>Grow your tree with every success.</p>
       <button className="btn-primary" onClick={handleAction}>Finish</button>

--- a/learning-games/src/components/ui/ProgressRing.css
+++ b/learning-games/src/components/ui/ProgressRing.css
@@ -1,0 +1,14 @@
+.progress-ring {
+  display: block;
+}
+.ring-bg {
+  fill: none;
+  stroke: rgba(0, 0, 0, 0.1);
+}
+.ring-progress {
+  fill: none;
+  stroke: var(--badho-accent-indigo);
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+  transition: stroke-dashoffset 0.35s;
+}

--- a/learning-games/src/components/ui/ProgressRing.tsx
+++ b/learning-games/src/components/ui/ProgressRing.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import './ProgressRing.css'
+
+interface Props {
+  progress: number
+  size?: number
+}
+
+export default function ProgressRing({ progress, size = 80 }: Props) {
+  const [offset, setOffset] = useState(0)
+  const radius = (size - 8) / 2
+  const circumference = 2 * Math.PI * radius
+
+  useEffect(() => {
+    const pct = Math.min(Math.max(progress, 0), 100)
+    const off = circumference - (pct / 100) * circumference
+    setOffset(off)
+  }, [progress, circumference])
+
+  return (
+    <svg className="progress-ring" width={size} height={size} viewBox={`0 0 ${size} ${size}`}>\
+      <circle className="ring-bg" strokeWidth="4" r={radius} cx={size / 2} cy={size / 2} />\
+      <circle
+        className="ring-progress"
+        strokeWidth="4"
+        r={radius}
+        cx={size / 2}
+        cy={size / 2}
+        style={{ strokeDasharray: `${circumference} ${circumference}`, strokeDashoffset: offset }}
+      />\
+    </svg>
+  )
+}

--- a/learning-games/src/components/willpowerWarrior.tsx
+++ b/learning-games/src/components/willpowerWarrior.tsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react'
 import { fetchChallenge, postAction } from '../services/aiService'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
+import './MiniGameBackgrounds.css'
+import { WillpowerBadge } from './icons'
 
 interface Props {
   ageGroup: string
@@ -21,7 +23,8 @@ export default function WillpowerWarrior({ ageGroup, onComplete }: Props) {
   }
 
   return (
-    <div>
+    <div className="willpower-bg">
+      <WillpowerBadge />
       <h2>Willpower Warrior</h2>
       <p>Overcome distractions to earn points.</p>
       <button className="btn-primary" onClick={handleAction}>Finish</button>

--- a/learning-games/src/constants/achievementGallery.ts
+++ b/learning-games/src/constants/achievementGallery.ts
@@ -1,0 +1,8 @@
+export const AchievementGallery = {
+  badges: {
+    bronze: { glow: '#CD7F32', animation: 'pulse' },
+    silver: { glow: '#C0C0C0', animation: 'shimmer' },
+    gold: { glow: '#FFD700', animation: 'sparkle' },
+    platinum: { glow: '#E5E4E2', animation: 'radiate' },
+  },
+} as const

--- a/learning-games/src/constants/soundThemes.ts
+++ b/learning-games/src/constants/soundThemes.ts
@@ -1,0 +1,6 @@
+export const SoundThemes = {
+  victory: 'triumphant-fanfare.mp3',
+  levelUp: 'power-surge.mp3',
+  collectBadge: 'crystal-chime.mp3',
+  gameStart: 'hero-awakens.mp3',
+} as const

--- a/learning-games/src/index.css
+++ b/learning-games/src/index.css
@@ -4,18 +4,36 @@
   font-weight: 400;
 
 
+  /* Base StrawberryTech palette */
   --color-purple: #f43f5e;
   --color-orange: #ff6b00;
   --color-lime: #a3e635;
   --color-blue: #1e3a8a;
   --color-purple-dark: #6d28d9;
-  /* BadhoHero palette */
 
-  --color-brand: #4caf50; /* Leaf Green */
-  --color-background: #ffc107; /* Sunflower Yellow */
-  --color-accent: #2196f3; /* Sky Blue */
-  --color-secondary: #ff9800; /* Warm Orange */
-  --color-deep-red: #303f9f; /* Accent Indigo */
+  /* BadhoHero dynamic theme */
+  --badho-leaf-green: #4caf50;
+  --badho-sunflower: #ffc107;
+  --badho-sky-blue: #2196f3;
+  --badho-accent-indigo: #303f9f;
+  --badho-warm-orange: #ff9800;
+
+  --badho-hero-gradient: linear-gradient(
+    135deg,
+    var(--badho-leaf-green),
+    var(--badho-sky-blue)
+  );
+  --badho-victory-gradient: linear-gradient(
+    45deg,
+    var(--badho-sunflower),
+    var(--badho-warm-orange)
+  );
+
+  --color-brand: var(--badho-leaf-green);
+  --color-background: var(--badho-sunflower);
+  --color-accent: var(--badho-sky-blue);
+  --color-secondary: var(--badho-warm-orange);
+  --color-deep-red: var(--badho-accent-indigo);
   --color-mint: #2196f3;
   --color-yellow: #ffc107;
   --color-text-dark: #333;
@@ -149,6 +167,22 @@ button:focus-visible {
   }
 }
 
+/* High contrast mode */
+@media (prefers-contrast: high) {
+  .game-element {
+    border: 3px solid currentColor;
+    filter: contrast(1.2);
+  }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 body.high-contrast {
   --color-brand: #000000;
   --color-orange: #000000;
@@ -204,10 +238,15 @@ body.high-contrast button {
 }
 
 .game-text {
-  line-height: 1.5;
-  font-size: 1rem;
+  font-size: clamp(1rem, 2vw + 0.5rem, 1.5rem);
+  font-family: 'Poppins', 'Noto Sans', sans-serif;
+  line-height: 1.6;
   color: #333;
 }
+
+.young-player { font-size: 120%; }
+.teen-player { font-size: 100%; }
+.adult-player { font-size: 90%; }
 
 .clearfix::after {
   content: '';


### PR DESCRIPTION
## Summary
- set up BadhoHero color tokens with gradients
- refresh game card styling
- add animated progress ring widget
- create animated SVG hero icons
- wire up parallax backgrounds for mini games
- define achievement gallery and sound themes
- tune typography and accessibility preferences

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm test` *(fails: unhandled errors)*
- `npm test` in `server` *(passes)*
- `npm test` in `nextjs-app` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852fb3e295c832f9d1bfe941ff12ee6