### PR TITLE
Add willpower and confidence scenes

### DIFF
--- a/docs/Component_Reference.md
+++ b/docs/Component_Reference.md
@@ -6,10 +6,11 @@ This document summarizes the main React components in the `learning-games` appli
 
 - **GameOrchestrator** – sequences the mini games. It reads the `ageGroup` from `UserContext`, renders each game component and advances when a game calls `onComplete`.
 - **FoglandAwakening** (`ageGroup: string`, `onComplete: () => void`) – introductory challenge clearing fog tiles.
-- **WillpowerWarrior** (`ageGroup: string`, `onComplete: () => void`) – fetches the `willpowerWarrior` challenge and awards points when the player finishes.
+- **WillpowerWarrior** (`ageGroup: string`, `onComplete: () => void`) – morning routine game where players choose healthy habits against the clock.
 - **GoalOrbQuest** (`ageGroup: string`, `onComplete: () => void`) – similar flow for the goal setting challenge.
 - **TimeTunnelTracker** (`ageGroup: string`, `onComplete: () => void`) – time management mini game.
 - **ConfidenceCavern** (`ageGroup: string`, `onComplete: () => void`) – confidence building challenge.
+- **ConfidenceCastle** (`ageGroup: string`, `onComplete: () => void`) – quick power‑pose exercise for facing fears.
 - **TreeOfTriumph** (`ageGroup: string`, `onComplete: () => void`) – success tracking challenge.
 - **PointsTracker** – singleton object with `addPoints(p: number)` and `getPoints()` methods.
 - **BadgesStore** – singleton with `earn(badge)` and `getBadges()`.

--- a/learning-games/src/components/ConfidenceCastle.css
+++ b/learning-games/src/components/ConfidenceCastle.css
@@ -1,0 +1,5 @@
+.confidence-castle {
+  padding: 2rem;
+  min-height: 100vh;
+  text-align: center;
+}

--- a/learning-games/src/components/GameOrchestrator.tsx
+++ b/learning-games/src/components/GameOrchestrator.tsx
@@ -4,6 +4,7 @@ import WillpowerWarrior from './willpowerWarrior'
 import GoalOrbQuest from './goalOrbQuest'
 import TimeTunnelTracker from './timeTunnelTracker'
 import ConfidenceCavern from './confidenceCavern'
+import ConfidenceCastle from './confidenceCastle'
 import TreeOfTriumph from './treeOfTriumph'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
@@ -16,6 +17,7 @@ const games = [
   GoalOrbQuest,
   TimeTunnelTracker,
   ConfidenceCavern,
+  ConfidenceCastle,
   TreeOfTriumph,
 ]
 

--- a/learning-games/src/components/WillpowerWarrior.css
+++ b/learning-games/src/components/WillpowerWarrior.css
@@ -1,0 +1,28 @@
+.willpower-warrior {
+  padding: 1rem;
+  min-height: 100vh;
+  text-align: center;
+}
+
+.routine-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.routine-tile {
+  height: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.routine-tile.selected {
+  opacity: 0.6;
+}

--- a/learning-games/src/components/confidenceCastle.tsx
+++ b/learning-games/src/components/confidenceCastle.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { fetchChallenge, postAction } from '../services/aiService'
+import PointsTracker from './PointsTracker'
+import BadgesStore from './BadgesStore'
+import NeumorphicButton from './ui/NeumorphicButton'
+import './MiniGameBackgrounds.css'
+import './ConfidenceCastle.css'
+
+interface Props {
+  ageGroup: string
+  onComplete: () => void
+}
+
+export default function ConfidenceCastle({ ageGroup, onComplete }: Props) {
+  const [started, setStarted] = useState(false)
+  const [timeLeft, setTimeLeft] = useState(5)
+  const [done, setDone] = useState(false)
+
+  useEffect(() => {
+    fetchChallenge('confidenceCastle', ageGroup)
+  }, [ageGroup])
+
+  useEffect(() => {
+    if (!started || done) return
+    if (timeLeft <= 0) {
+      setDone(true)
+      return
+    }
+    const t = setTimeout(() => setTimeLeft((t) => t - 1), 1000)
+    return () => clearTimeout(t)
+  }, [started, timeLeft, done])
+
+  function startPose() {
+    setStarted(true)
+    setTimeLeft(5)
+  }
+
+  function finish() {
+    PointsTracker.addPoints(10)
+    BadgesStore.earn('confidence')
+    postAction('confidenceCastle', { action: 'complete' })
+    onComplete()
+  }
+
+  return (
+    <div className="confidence-bg confidence-castle">
+      <h2>Confidence Castle</h2>
+      {!started && (
+        <NeumorphicButton onClick={startPose}>Start Power Pose</NeumorphicButton>
+      )}
+      {started && !done && <p>Hold it... {timeLeft}</p>}
+      {done && (
+        <NeumorphicButton onClick={finish} style={{ marginTop: '1rem' }}>
+          Finish
+        </NeumorphicButton>
+      )}
+    </div>
+  )
+}

--- a/learning-games/src/components/willpowerWarrior.tsx
+++ b/learning-games/src/components/willpowerWarrior.tsx
@@ -1,41 +1,134 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { fetchChallenge, postAction } from '../services/aiService'
 import PointsTracker from './PointsTracker'
 import BadgesStore from './BadgesStore'
-import './MiniGameBackgrounds.css'
-import GlassCard from './ui/GlassCard'
+import Card from './ui/card'
+import ProgressBar from './ui/ProgressBar'
 import NeumorphicButton from './ui/NeumorphicButton'
-import AnimatedAvatar from './ui/AnimatedAvatar'
-import MoodLighting from './ui/MoodLighting'
-import ParticleSystem from './ui/ParticleSystem'
+import './MiniGameBackgrounds.css'
+import './WillpowerWarrior.css'
+
+interface RoutineTile {
+  id: number
+  emoji: string
+  label: string
+  healthy: boolean
+  selected?: boolean
+}
 
 interface Props {
   ageGroup: string
   onComplete: () => void
 }
 
+const BASE_TILES: RoutineTile[] = [
+  { id: 1, emoji: '🛏️', label: 'Make Bed', healthy: true },
+  { id: 2, emoji: '🪥', label: 'Brush Teeth', healthy: true },
+  { id: 3, emoji: '📚', label: 'Open Textbook', healthy: true },
+  { id: 4, emoji: '📺', label: 'Watch TV News', healthy: false },
+  { id: 5, emoji: '📱', label: 'Scroll Social Media', healthy: false },
+  { id: 6, emoji: '🥛', label: 'Drink Water', healthy: true },
+  { id: 7, emoji: '🍞', label: 'Eat Breakfast', healthy: true },
+  { id: 8, emoji: '📰', label: 'Read Newspaper', healthy: false },
+  { id: 9, emoji: '⏰', label: 'Set 5 more alarms', healthy: false },
+  { id: 10, emoji: '💤', label: 'Snooze', healthy: false },
+]
+
+const ROUND_TIMES = [30, 25, 20]
+
+function shuffle<T>(arr: T[]): T[] {
+  const copy = [...arr]
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[copy[i], copy[j]] = [copy[j], copy[i]]
+  }
+  return copy
+}
+
 export default function WillpowerWarrior({ ageGroup, onComplete }: Props) {
+  const [round, setRound] = useState(0)
+  const [tiles, setTiles] = useState<RoutineTile[]>([])
+  const [timeLeft, setTimeLeft] = useState(ROUND_TIMES[0])
+  const [score, setScore] = useState(0)
+  const [running, setRunning] = useState(false)
+
   useEffect(() => {
     fetchChallenge('willpowerWarrior', ageGroup)
+    startRound(0)
   }, [ageGroup])
 
-  function handleAction() {
-    PointsTracker.addPoints(10)
-    BadgesStore.earn('willpower')
-    postAction('willpowerWarrior', { action: 'complete' })
-    ParticleSystem.burst()
-    onComplete()
+  useEffect(() => {
+    if (!running) return
+    if (timeLeft <= 0) {
+      endRound()
+      return
+    }
+    const t = setTimeout(() => setTimeLeft((t) => t - 1), 1000)
+    return () => clearTimeout(t)
+  }, [timeLeft, running])
+
+  function startRound(n: number) {
+    setRound(n + 1)
+    setTiles(shuffle(BASE_TILES))
+    setTimeLeft(ROUND_TIMES[n])
+    setRunning(true)
   }
 
+  function endRound() {
+    setRunning(false)
+    const bonus = tiles.every((t) => !t.healthy || t.selected) ? 20 : 0
+    setScore((s) => s + bonus)
+    if (round >= 3) {
+      const finalScore = score + bonus
+      PointsTracker.addPoints(finalScore)
+      BadgesStore.earn('willpower')
+      postAction('willpowerWarrior', { score: finalScore })
+      onComplete()
+    }
+  }
+
+  function handleTile(id: number) {
+    if (!running) return
+    const tile = tiles.find((t) => t.id === id)
+    if (!tile || tile.selected) return
+    setTiles((ts) => ts.map((t) => (t.id === id ? { ...t, selected: true } : t)))
+    setScore((s) => s + (tile.healthy ? 10 : -7))
+    const allClear = tiles.every((t) => !t.healthy || t.selected || t.id === id)
+    if (allClear) endRound()
+  }
+
+  function nextRound() {
+    startRound(round)
+  }
+
+  const roundComplete = !running && round < 3
+
   return (
-    <div className="willpower-bg" style={{ position: 'relative', padding: '2rem' }}>
-      <MoodLighting />
-      <GlassCard>
-        <AnimatedAvatar />
-        <h2>Willpower Warrior</h2>
-        <p>Overcome distractions to earn points.</p>
-        <NeumorphicButton onClick={handleAction}>Finish</NeumorphicButton>
-      </GlassCard>
+    <div className="willpower-bg willpower-warrior">
+      <h2>Willpower Warrior</h2>
+      <p>
+        Round {round} / 3 &nbsp; Score: {score} &nbsp; Time: {timeLeft}s
+      </p>
+      <ProgressBar percent={(timeLeft / ROUND_TIMES[round - 1]) * 100} />
+      <div className="routine-grid">
+        {tiles.map((tile) => (
+          <Card
+            key={tile.id}
+            className={`routine-tile ${tile.selected ? 'selected' : ''}`}
+            onClick={() => handleTile(tile.id)}
+          >
+            <span style={{ fontSize: '1.5rem' }} role="img" aria-label={tile.label}>
+              {tile.emoji}
+            </span>
+            <div>{tile.label}</div>
+          </Card>
+        ))}
+      </div>
+      {roundComplete && (
+        <NeumorphicButton onClick={nextRound} style={{ marginTop: '1rem' }}>
+          Next Round
+        </NeumorphicButton>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- implement WillpowerWarrior morning routine mini game
- add ConfidenceCastle power pose scene
- include new scenes in GameOrchestrator
- document the new components

## Testing
- `npm run test` *(fails: unable to find elements in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68531874c250832f8706aea0f7d64c68