### PR TITLE
Add two new minigame scenes

### DIFF
--- a/nextjs-app/src/pages/games/goalsort.tsx
+++ b/nextjs-app/src/pages/games/goalsort.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import ModernGameLayout from '../../components/layout/ModernGameLayout'
+import WhyCard from '../../components/layout/WhyCard'
+import confetti from 'canvas-confetti'
+import styles from '../../styles/GoalTimeGames.module.css'
+
+interface Orb {
+  id: number
+  label: string
+  category: 'short' | 'medium' | 'long'
+}
+
+const ORBS: Orb[] = [
+  { id: 1, label: "Finish today's homework", category: 'short' },
+  { id: 2, label: 'Read a book this month', category: 'medium' },
+  { id: 3, label: 'Help family with chores', category: 'short' },
+  { id: 4, label: 'Save 500 rupees', category: 'medium' },
+  { id: 5, label: 'Start a hobby', category: 'medium' },
+  { id: 6, label: 'Win the sports match', category: 'short' },
+  { id: 7, label: 'Score high in exams this year', category: 'long' },
+  { id: 8, label: 'Improve at math', category: 'long' },
+]
+
+export default function GoalSortGame() {
+  const [remaining, setRemaining] = useState(ORBS)
+  const [placed, setPlaced] = useState({
+    short: [] as Orb[],
+    medium: [] as Orb[],
+    long: [] as Orb[],
+  })
+  const [score, setScore] = useState(0)
+  const [message, setMessage] = useState('')
+
+  function onDragStart(e: React.DragEvent<HTMLDivElement>, id: number) {
+    e.dataTransfer.setData('text/plain', String(id))
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>, cat: 'short'|'medium'|'long') {
+    e.preventDefault()
+    const id = Number(e.dataTransfer.getData('text/plain'))
+    const orb = remaining.find(o => o.id === id)
+    if (!orb) return
+    if (placed[cat].length >= 2) {
+      setScore(s => s - 10)
+      setMessage('That portal is full!')
+      return
+    }
+    setRemaining(rem => rem.filter(o => o.id !== id))
+    setPlaced(p => ({ ...p, [cat]: [...p[cat], orb] }))
+    if (orb.category === cat) {
+      setScore(s => s + 15)
+    } else {
+      setScore(s => s - 10)
+      setMessage('Oops, wrong portal!')
+    }
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault()
+  }
+
+  const allDone = remaining.length === 0
+  if (allDone) {
+    confetti({ particleCount: 80, spread: 70 })
+  }
+
+  return (
+    <ModernGameLayout
+      gameTitle="Goal-Orb Discovery"
+      gameIcon="https://raw.githubusercontent.com/unnamedmistress/images/main/goal-orb.png"
+      whyCard={
+        <WhyCard
+          title="Why Sort Goals?"
+          explanation="When you know what matters most, you progress faster. Too many goals in one place get stuck!"
+        />
+      }
+    >
+      <div className={styles.goalGame}>
+        <p>Drag each goal orb into the correct time portal.</p>
+        <div className={styles.orbList}>
+          {remaining.map(o => (
+            <div
+              key={o.id}
+              className={styles.orb}
+              draggable
+              onDragStart={e => onDragStart(e, o.id)}
+            >
+              {o.label}
+            </div>
+          ))}
+        </div>
+        <div className={styles.portals}>
+          {(['short','medium','long'] as const).map(cat => (
+            <div
+              key={cat}
+              className={`${styles.portal} ${placed[cat].length>=2 ? styles.portalFull:''}`}
+              onDrop={e => handleDrop(e, cat)}
+              onDragOver={handleDragOver}
+            >
+              <strong>{cat === 'short' ? 'Short-Term' : cat === 'medium' ? 'Medium-Term' : 'Long-Term'}</strong>
+              <div>
+                {placed[cat].map(o => (
+                  <div key={o.id}>{o.label}</div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        {message && <p>{message}</p>}
+        {allDone && <p>You scored {score} points!</p>}
+      </div>
+    </ModernGameLayout>
+  )
+}
+
+export function Head() {
+  return (
+    <>
+      <title>Goal-Orb Discovery | StrawberryTech</title>
+      <meta name="description" content="Sort your goals to advance" />
+    </>
+  )
+}
+
+export const getStaticProps = async () => ({ props: {} })

--- a/nextjs-app/src/pages/games/time-tunnel.tsx
+++ b/nextjs-app/src/pages/games/time-tunnel.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+import ModernGameLayout from '../../components/layout/ModernGameLayout'
+import WhyCard from '../../components/layout/WhyCard'
+import confetti from 'canvas-confetti'
+import styles from '../../styles/GoalTimeGames.module.css'
+
+interface Task { id: number; label: string }
+
+const TASKS: Task[] = [
+  { id: 1, label: 'Find your bag' },
+  { id: 2, label: 'Gather textbooks' },
+  { id: 3, label: 'Collect stationery' },
+  { id: 4, label: 'Pack homework' },
+  { id: 5, label: 'Add lunch' },
+  { id: 6, label: 'Pack water bottle' },
+  { id: 7, label: 'Put in school ID' },
+  { id: 8, label: 'Scroll phone' },
+]
+
+export default function TimeTunnelGame() {
+  const [order, setOrder] = useState(() => TASKS.sort(() => 0.5 - Math.random()))
+  const [index, setIndex] = useState(0)
+  const [score, setScore] = useState(0)
+  const [message, setMessage] = useState('')
+  const [timeLeft, setTimeLeft] = useState(60)
+
+  useEffect(() => {
+    const id = setInterval(() => setTimeLeft(t => t - 1), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  useEffect(() => {
+    if (timeLeft <= 0) setMessage('Time up!')
+  }, [timeLeft])
+
+  function choose(task: Task) {
+    if (timeLeft <= 0) return
+    if (index >= TASKS.length) return
+    const correct = TASKS[index]
+    if (task.id === correct.id) {
+      setScore(s => s + 12)
+      setIndex(i => i + 1)
+      if (index + 1 === TASKS.length) {
+        confetti({ particleCount: 80, spread: 70 })
+        if (score + 12 === TASKS.length * 12) setScore(s => s + 25)
+        setMessage('All done!')
+      }
+    } else {
+      setScore(s => s - 10)
+      setMessage('Wrong step!')
+    }
+  }
+
+  return (
+    <ModernGameLayout
+      gameTitle="Time Tunnel Trials"
+      gameIcon="https://raw.githubusercontent.com/unnamedmistress/images/main/time-tunnel.png"
+      whyCard={
+        <WhyCard
+          title="Why Sequence Matters"
+          explanation="Doing things in order saves time and makes you feel ready. Laziness is doing the easy stuff first." />
+      }
+    >
+      <div className={styles.timeGame}>
+        <p>Time left: {timeLeft}s</p>
+        <div className={styles.tasks}>
+          {order.map(t => (
+            <button
+              key={t.id}
+              className={`${styles.task} ${index > order.indexOf(t) ? styles.completed : ''}`}
+              onClick={() => choose(t)}
+              disabled={index > order.indexOf(t) || timeLeft <= 0}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        {message && <p>{message} Score: {score}</p>}
+      </div>
+    </ModernGameLayout>
+  )
+}
+
+export function Head() {
+  return (
+    <>
+      <title>Time Tunnel Trials | StrawberryTech</title>
+      <meta name="description" content="Pack your bag efficiently" />
+    </>
+  )
+}
+
+export const getStaticProps = async () => ({ props: {} })

--- a/nextjs-app/src/styles/GoalTimeGames.module.css
+++ b/nextjs-app/src/styles/GoalTimeGames.module.css
@@ -1,0 +1,66 @@
+.goalGame {
+  padding: 2rem 1rem;
+}
+
+.orbList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.orb {
+  padding: 0.5rem 0.75rem;
+  background: var(--color-purple);
+  color: #fff;
+  border-radius: 20px;
+  cursor: grab;
+  user-select: none;
+}
+
+.portals {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+}
+
+.portal {
+  border: 2px dashed var(--color-blue);
+  border-radius: 8px;
+  padding: 1rem;
+  min-height: 60px;
+  width: 100%;
+  max-width: 260px;
+  text-align: center;
+}
+
+.portalFull {
+  opacity: 0.6;
+}
+
+.timeGame {
+  padding: 2rem 1rem;
+}
+
+.tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.task {
+  padding: 0.5rem 0.75rem;
+  background: var(--color-green);
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.completed {
+  background: var(--color-purple);
+}


### PR DESCRIPTION
## Summary
- add Goal-Orb Discovery page for sorting goal orbs
- add Time Tunnel Trials page for task sequencing
- include shared styles for both scenes

## Testing
- `npm run lint` *(fails: next command not found initially, then many lint errors)*
- `npm test` *(fails: vitest not found / tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68531c3f6468832fa3060a1514b4e9a7