### PR TITLE
Add Confidence Cavern and Tree of Triumph scenes

### DIFF
--- a/learning-games/src/utils/__tests__/generateRoomDescription.test.ts
+++ b/learning-games/src/utils/__tests__/generateRoomDescription.test.ts
@@ -12,7 +12,7 @@ describe('generateRoomDescription', () => {
     const mock = vi.fn().mockResolvedValue({
       json: () => Promise.resolve({ choices: [{ message: { content: 'room' } }] }),
     })
-    global.fetch = mock as any
+    global.fetch = mock as unknown as typeof fetch
     await generateRoomDescription('teen')
     const body = JSON.parse(mock.mock.calls[0][1].body)
     expect(body.messages[0].content).toContain('teen')

--- a/src/game/scenes/ConfidenceCavern.tsx
+++ b/src/game/scenes/ConfidenceCavern.tsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import confetti from 'canvas-confetti'
+import './confidence-tree-scenes.css'
+
+interface Challenge {
+  id: number
+  prompt: string
+}
+
+const CHALLENGES: Challenge[] = [
+  { id: 1, prompt: 'Share how you will finish your homework today.' },
+  { id: 2, prompt: 'Describe one new thing you will try this week.' },
+  { id: 3, prompt: 'Write a sentence encouraging yourself before a test.' },
+  { id: 4, prompt: 'How will you help a friend feel better?' },
+  { id: 5, prompt: 'Name a small step toward a big goal.' },
+  { id: 6, prompt: 'Write something brave you can do tomorrow.' },
+  { id: 7, prompt: 'Encourage yourself to talk to someone new.' },
+  { id: 8, prompt: 'Finish with your best confidence statement!' }
+]
+
+function evaluate(text: string) {
+  const lower = text.toLowerCase()
+  const negativeWords = ['no', "don't", "can't", 'never', 'not']
+  const hasNegative = negativeWords.some((w) => lower.includes(w))
+  if (hasNegative || lower.trim().length === 0) {
+    return { points: 0, message: 'Try again without negative words.' }
+  }
+  const strongWords = ['will', 'can', 'am', 'do', 'going']
+  const strong = strongWords.some((w) => lower.includes(w)) && lower.length > 20
+  if (strong) {
+    return { points: 15, message: 'Great affirmation!' }
+  }
+  return { points: 7, message: 'Good, make it even stronger next time.' }
+}
+
+export default function ConfidenceCavern() {
+  const [index, setIndex] = useState(0)
+  const [input, setInput] = useState('')
+  const [score, setScore] = useState(0)
+  const [foxMsg, setFoxMsg] = useState('')
+
+  const brightness = 0.1 + index * 0.1
+
+  useEffect(() => {
+    if (index === CHALLENGES.length) {
+      confetti({ particleCount: 150, spread: 90 })
+    }
+  }, [index])
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const { points, message } = evaluate(input)
+    setFoxMsg(message)
+    if (points > 0) {
+      setScore((s) => s + points)
+      setIndex((i) => i + 1)
+      setInput('')
+    }
+  }
+
+  if (index >= CHALLENGES.length) {
+    return (
+      <div className="confidence-cavern" style={{ filter: `brightness(1)` }}>
+        <h2>Confidence Cavern Complete!</h2>
+        <p>Total Score: {score}</p>
+      </div>
+    )
+  }
+
+  const challenge = CHALLENGES[index]
+
+  return (
+    <div
+      className="confidence-cavern"
+      style={{ filter: `brightness(${brightness})` }}
+    >
+      <h2>Confidence Cavern</h2>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={challenge.id}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+        >
+          <p>{challenge.prompt}</p>
+          <form onSubmit={handleSubmit}>
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              style={{ width: '80%', padding: '0.5rem' }}
+            />
+            <div style={{ marginTop: '0.5rem' }}>
+              <button type="submit">Submit</button>
+            </div>
+          </form>
+        </motion.div>
+      </AnimatePresence>
+      <div className="cavern-fox">{foxMsg}</div>
+      <div className="torch-grid">
+        {CHALLENGES.map((t, i) => (
+          <div key={t.id} className={`torch ${i < index ? 'lit' : ''}`} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/game/scenes/TreeOfTriumph.tsx
+++ b/src/game/scenes/TreeOfTriumph.tsx
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import confetti from 'canvas-confetti'
+import './confidence-tree-scenes.css'
+
+interface Badge {
+  id: string
+  label: string
+}
+
+const BADGES: Badge[] = [
+  { id: 'origin', label: 'Origin' },
+  { id: 'willpower', label: 'Will' },
+  { id: 'goal', label: 'Goal' },
+  { id: 'timekeeper', label: 'Time' },
+  { id: 'confidence', label: 'Conf' },
+  { id: 'triumph', label: 'Triumph' }
+]
+
+export default function TreeOfTriumph() {
+  const [planted, setPlanted] = useState<Badge[]>([])
+  const [watering, setWatering] = useState(0)
+  const [height, setHeight] = useState(40)
+  const [fruits, setFruits] = useState<{ x: number; y: number }[]>([])
+
+  useEffect(() => {
+    if (planted.length === BADGES.length) {
+      confetti({ particleCount: 200, spread: 100 })
+    }
+  }, [planted])
+
+  function handleDrop(badge: Badge) {
+    if (planted.find((b) => b.id === badge.id)) return
+    setPlanted((b) => [...b, badge])
+    setWatering(0)
+  }
+
+  function water() {
+    const next = watering + 1
+    setWatering(next)
+    if (next >= 5) {
+      setHeight((h) => h + 30)
+      setWatering(0)
+      // add fruit using golden angle
+      const angle = fruits.length * 137.5
+      const radius = 40 + fruits.length * 4
+      setFruits((f) => [
+        ...f,
+        {
+          x: radius * Math.cos((angle * Math.PI) / 180),
+          y: radius * Math.sin((angle * Math.PI) / 180)
+        }
+      ])
+    }
+  }
+
+  return (
+    <div className="tree-of-triumph">
+      <h2>Tree of Triumph</h2>
+      <div className="badge-row">
+        {BADGES.map((b) => (
+          <div
+            key={b.id}
+            className="badge"
+            draggable
+            onDragStart={(e) => e.dataTransfer.setData('id', b.id)}
+          >
+            {b.label}
+          </div>
+        ))}
+      </div>
+      <div
+        className="soil"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          const id = e.dataTransfer.getData('id')
+          const badge = BADGES.find((b) => b.id === id)
+          if (badge) handleDrop(badge)
+        }}
+      >
+        <motion.div
+          className="tree"
+          style={{ height: `${height}px` }}
+          animate={{ height }}
+        >
+          {fruits.map((f, i) => (
+            <div
+              key={i}
+              className="fruit"
+              style={{
+                left: `${50 + f.x}px`,
+                bottom: `${height + f.y}px`
+              }}
+            />
+          ))}
+        </motion.div>
+      </div>
+      {planted.length > 0 && (
+        <div style={{ marginTop: '1rem' }}>
+          <button onClick={water}>Water ({watering}/5)</button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/game/scenes/confidence-tree-scenes.css
+++ b/src/game/scenes/confidence-tree-scenes.css
@@ -1,0 +1,90 @@
+/* Confidence Cavern Styles */
+.confidence-cavern {
+  min-height: 100vh;
+  padding: 40px 20px;
+  background: linear-gradient(to bottom, #1e293b 0%, #0f172a 100%);
+  color: #fff;
+  text-align: center;
+}
+
+.torch-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.torch {
+  width: 60px;
+  height: 120px;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  position: relative;
+}
+
+.torch.lit::after {
+  content: '🔥';
+  position: absolute;
+  top: -30px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 2rem;
+}
+
+.cavern-fox {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+}
+
+/* Tree of Triumph Styles */
+.tree-of-triumph {
+  min-height: 100vh;
+  padding: 40px 20px;
+  background: linear-gradient(to bottom, #14532d 0%, #022c22 100%);
+  color: #fff;
+  text-align: center;
+}
+
+.badge-row {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.badge {
+  width: 60px;
+  height: 60px;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+}
+
+.soil {
+  height: 100px;
+  background: #4b2e05;
+  margin-top: 1rem;
+  position: relative;
+}
+
+.tree {
+  width: 10px;
+  background: #3f6212;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.fruit {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  background: #fbbf24;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- create new game scenes `ConfidenceCavern` and `TreeOfTriumph`
- basic styles for the finale scenes
- minor type fix for `generateRoomDescription.test.ts`

## Testing
- `npm run lint` in `learning-games` *(fails: 3 warnings)*
- `npm test` in `learning-games` *(fails to run tests)*
- `npm test` in `server`
- `npm test` in `nextjs-app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685324c77c64832f843c97e2f5d46b62