### PR TITLE
Fix image URLs

### DIFF
--- a/docs/ImageIntegrationPlan.md
+++ b/docs/ImageIntegrationPlan.md
@@ -6,13 +6,13 @@ This plan explains how to incorporate a themed strawberry image on every page in
 
 | File Name | Description | URL |
 | --- | --- | --- |
-| ChatGPT Image Jun 7, 2025, 07_51_28 PM.png | Detective-themed strawberry examining statement cards under magnifying glass to spot false claim. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png |
-| ChatGPT Image Jun 7, 2025, 07_47_46 PM.png | Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png |
-| ChatGPT Image Jun 7, 2025, 07_47_29 PM.png | Another version of strawberry calling out sick, same description. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_29%20PM.png |
-| ChatGPT Image Jun 7, 2025, 07_24_00 PM.png | Strawberry throwing dart hitting "Clear Prompt" bullseye on prompt darts target. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png |
-| ChatGPT Image Jun 7, 2025, 07_19_23 PM.png | Prompt recipe builder strawberry chef tossing cards labeled Action, Context, Format, Constraints. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png |
-| ChatGPT Image Jun 7, 2025, 07_16_34 PM.png | Earlier prompt recipe builder with similar strawberry chef and cards. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png |
-| ChatGPT Image Jun 7, 2025, 07_12_36 PM.png | Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones. | https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_51_28 PM.png | Detective-themed strawberry examining statement cards under magnifying glass to spot false claim. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_51_28%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_47_46 PM.png | Strawberry calling out sick wrapped in blanket, holding phone with polite sick day message bubble. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_46%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_47_29 PM.png | Another version of strawberry calling out sick, same description. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_47_29%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_24_00 PM.png | Strawberry throwing dart hitting "Clear Prompt" bullseye on prompt darts target. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_24_00%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_19_23 PM.png | Prompt recipe builder strawberry chef tossing cards labeled Action, Context, Format, Constraints. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_19_23%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_16_34 PM.png | Earlier prompt recipe builder with similar strawberry chef and cards. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_16_34%20PM.png |
+| ChatGPT Image Jun 7, 2025, 07_12_36 PM.png | Home page strawberry mascot welcomes players at entrance of learning arcade with pastel tones. | https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%207%2C%202025%2C%2007_12_36%20PM.png |
 
 All images are hosted on GitHub. Use the direct URL in the `src` attribute of an `<img>` tag and include an `alt` text that matches the description above.
 

--- a/nextjs-app/src/pages/_app.tsx
+++ b/nextjs-app/src/pages/_app.tsx
@@ -51,7 +51,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <meta property="og:type" content="website" />
         <meta property="og:title" content="StrawberryTech - Master AI Prompting Through Games" />
         <meta property="og:description" content={description} />
-        <meta property="og:site_name" content="StrawberryTech" />        <meta property="og:image" content="https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
+        <meta property="og:site_name" content="StrawberryTech" />        <meta property="og:image" content="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
         <meta property="og:image:width" content="1024" />
         <meta property="og:image:height" content="1024" />
         <meta property="og:image:alt" content="StrawberryTech - Learn AI Prompting Skills" />
@@ -63,7 +63,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <meta name="twitter:site" content="@strawberrytech" />
         <meta name="twitter:creator" content="@strawberrytech" />
         <meta name="twitter:title" content="StrawberryTech - Master AI Prompting Through Games" />
-        <meta name="twitter:description" content={description} />        <meta name="twitter:image" content="https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
+        <meta name="twitter:description" content={description} />        <meta name="twitter:image" content="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
         <meta name="twitter:image:alt" content="StrawberryTech - Learn AI Prompting Skills" />
         
         {/* Additional meta tags for better social sharing */}

--- a/nextjs-app/src/pages/community.tsx
+++ b/nextjs-app/src/pages/community.tsx
@@ -218,7 +218,7 @@ export function Head() {
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://strawberry-tech.vercel.app/community" />
       <meta property="og:title" content="StrawberryTech Community - AI Prompting Skills" />
-      <meta property="og:description" content="Join thousands learning AI prompting skills through fun, interactive games. Share your progress and connect with other learners!" />      <meta property="og:image" content="https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
+      <meta property="og:description" content="Join thousands learning AI prompting skills through fun, interactive games. Share your progress and connect with other learners!" />      <meta property="og:image" content="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
       <meta property="og:image:width" content="1024" />
       <meta property="og:image:height" content="1024" />
       <meta property="og:image:alt" content="StrawberryTech Community - Share your AI learning progress" />
@@ -231,7 +231,7 @@ export function Head() {
       <meta property="twitter:creator" content="@strawberrytech" />
       <meta property="twitter:url" content="https://strawberry-tech.vercel.app/community" />
       <meta property="twitter:title" content="StrawberryTech Community - AI Prompting Skills" />
-      <meta property="twitter:description" content="Join thousands learning AI prompting skills through fun, interactive games. Share your progress and connect with other learners!" />      <meta property="twitter:image" content="https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
+      <meta property="twitter:description" content="Join thousands learning AI prompting skills through fun, interactive games. Share your progress and connect with other learners!" />      <meta property="twitter:image" content="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
       <meta property="twitter:image:alt" content="StrawberryTech Community - Share your AI learning progress" />
       
       {/* Additional social sharing optimization */}

--- a/nextjs-app/src/pages/prompt-library.tsx
+++ b/nextjs-app/src/pages/prompt-library.tsx
@@ -347,7 +347,7 @@ export function Head() {
       <meta property="og:url" content="https://strawberry-tech.vercel.app/prompt-library" />
       <meta property="og:title" content="AI Prompt Library | StrawberryTech" />
       <meta property="og:description" content="Discover and share powerful AI prompts for education, creativity, business, and more. Browse our curated collection of prompts to enhance your AI interactions." />
-      <meta property="og:image" content="https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
+      <meta property="og:image" content="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
       <meta property="og:image:width" content="1024" />
       <meta property="og:image:height" content="1024" />
       <meta property="og:image:alt" content="StrawberryTech Prompt Library - AI Prompts Collection" />
@@ -359,7 +359,7 @@ export function Head() {
       <meta property="twitter:url" content="https://strawberry-tech.vercel.app/prompt-library" />
       <meta property="twitter:title" content="AI Prompt Library | StrawberryTech" />
       <meta property="twitter:description" content="Discover and share powerful AI prompts for education, creativity, business, and more." />
-      <meta property="twitter:image" content="https://github.com/unnamedmistress/images/blob/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
+      <meta property="twitter:image" content="https://raw.githubusercontent.com/unnamedmistress/images/main/ChatGPT%20Image%20Jun%206%2C%202025%2C%2011_20_14%20AM.png" />
       
       <meta name="keywords" content="AI prompts, artificial intelligence, prompt engineering, ChatGPT prompts, AI tools, machine learning" />
     </>


### PR DESCRIPTION
## Summary
- point image references to GitHub raw URLs
- update image links in docs

## Testing
- `npm test` in `learning-games` *(fails: vitest not found)*
- `npm test` in `nextjs-app`
- `npm test` in `server` *(fails: cannot find module 'supertest')*

------
https://chatgpt.com/codex/tasks/task_e_68532d88b5ac832face97d32de139fa9